### PR TITLE
Update result serialization to match js data

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 const { output, input: q } = require('alfy')
-result = eval(q)
+const evaluation = eval(q)
+const result = JSON.stringify(evaluation)
 output([
   {
     title: result,


### PR DESCRIPTION

This resolves an issue where `{foo: "bar"}` is evaluated as `foo` due to incorrect `.toString` applied.
Manually serializing the result to a string assures the results match what you may get from the actual node repl.